### PR TITLE
Rm-cantrill-refs

### DIFF
--- a/certification.md
+++ b/certification.md
@@ -11,7 +11,7 @@ The answer is probably no.  It's nice that they got one, and sometimes it's a re
 # So there's no point in getting a certification?
 
 Not correct.<br/>
-Getting the certifications won't secure the position, but studying for them will be an invaluable experience and that's why it's so important to find quality course materials and don't [just try to pass.](https://www.linkedin.com/pulse/fake-certs-what-why-theyre-bad-adrian-cantrill)<br/>
+Getting the certifications won't secure the position, but studying for them will be an invaluable experience and that's why it's so important to find quality course materials and don't just try to pass.<br/>
 TL;DR AWS exams don't cover everything you should know in order to get hired.  
 
 For a longer explanation, check out [this post.](https://digitalcloud.training/why-an-aws-certification-will-not-get-you-an-aws-job/)

--- a/general.md
+++ b/general.md
@@ -1,10 +1,10 @@
 # Communities (in no particular order)
-1. Learn.cantrill.io Slack - [https://techstudyslack.com/](https://techstudyslack.com/)
+1. AWS Community Discord - [https://discord.gg/aws](https://discord.gg/aws) 
 2. [NetworkChuck](https://www.linkedin.com/in/chuckkeith/) Discord - [https://discord.gg/networkchuck](https://discord.gg/networkchuck)
 3. Tortoise - Python Beginner Discord - [https://discord.com/invite/grtzHzgz](https://discord.com/invite/grtzHzgz)
 4. OG-AWS Slack - [https://og-aws-slack.lexikon.io/](https://og-aws-slack.lexikon.io/)
 5. DevOpsChatCo Slack - [https://devopschat.co/register](https://devopschat.co/register)
-6. AWS Community Discord - [https://discord.gg/JN9FMbm](https://discord.gg/JN9FMbm) 
+6. AWS Amplify Discord - [https://discord.gg/EfBrPyQd](https://discord.gg/EfBrPyQd)
 
 
 # Related AWS Github Repos

--- a/general.md
+++ b/general.md
@@ -4,7 +4,7 @@
 3. Tortoise - Python Beginner Discord - [https://discord.com/invite/grtzHzgz](https://discord.com/invite/grtzHzgz)
 4. OG-AWS Slack - [https://og-aws-slack.lexikon.io/](https://og-aws-slack.lexikon.io/)
 5. DevOpsChatCo Slack - [https://devopschat.co/register](https://devopschat.co/register)
-6. AWS Amplify Discord - [https://discord.gg/EfBrPyQd](https://discord.gg/EfBrPyQd)
+6. AWS Amplify Official Discord - [https://discord.gg/EfBrPyQd](https://discord.gg/EfBrPyQd)
 
 
 # Related AWS Github Repos


### PR DESCRIPTION
Removing a Cantrill link I noticed based on what we discussed previously. Also added a link to the AWS-run Amplify Discord

-megamush on Discord